### PR TITLE
Fix `_onChangeCallback` undefined

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -186,7 +186,7 @@ var CodemirrorComponent = exports.CodemirrorComponent = (_dec = (0, _core.Compon
     set: function set(v) {
       if (v !== this._value) {
         this._value = v;
-        this._onChangeCallback(v);
+        this.onChange(v);
       }
     }
   }]);

--- a/src/Codemirror.es6
+++ b/src/Codemirror.es6
@@ -48,7 +48,7 @@ export class CodemirrorComponent {
   @Input() set value(v) {
     if (v !== this._value) {
       this._value = v;
-      this._onChangeCallback(v);
+      this.onChange(v);
     }
   }
 


### PR DESCRIPTION
Fixes the following error: `error_handler.js:51 TypeError: this._onChangeCallback is not a function`