### PR TITLE
Implemented setDisabledState method to support disable

### DIFF
--- a/src/codemirror.component.ts
+++ b/src/codemirror.component.ts
@@ -118,4 +118,7 @@ export class CodemirrorComponent implements AfterViewInit, OnDestroy {
   onTouched() {}
   registerOnChange(fn) { this.onChange = fn; }
   registerOnTouched(fn) { this.onTouched = fn; }
+  setDisabledState(isDisabled: boolean): void { 	  
+	this.instance.setOption('readOnly', isDisabled ? 'nocursor' : isDisabled);
+  }
 }


### PR DESCRIPTION
Currently the control doesn't implement this method of the ControlValueAccesor, so specifying `disabled: true`  when creating the form group or calling the `enable()` or `disable()` method from the control have no effect. The only way to achieve it was to set the option `readOnly` of the Codemirror config directly. 


