### PR TITLE
core(package): update for angular >4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "zone.js": "^0.8.5"
   },
   "peerDependencies": {
-    "@angular/core": "^2.1.0 || ^4.0.0",
-    "@angular/forms": "^2.1.0 || ^4.0.0",
-    "@angular/common": "^2.1.0 || ^4.0.0"
+    "@angular/core": "^2.1.0 || >=4.0.0",
+    "@angular/forms": "^2.1.0 || >=4.0.0",
+    "@angular/common": "^2.1.0 || >=4.0.0"
   }
 }


### PR DESCRIPTION
When using ng2-codemirror in an Angular 6 project an `incorrect peer dependency ` warning appears, this PR solves the issue. 

Note: everything still runs great on Angular 6. It's just an install warning. 

fixes #39